### PR TITLE
Set new root databases with `All` group permissions

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -172,6 +172,20 @@ const main = async () => {
   app.listen(parseInt(process.env.PORT!), () => {
     console.log("server sarted on localhost:4000");
   });
+
+  // Setup 'Admin' and 'All' roles if they do not exist
+
+  const adminGroup = await Group.findOne({ name: "Admin" });
+  if (!adminGroup) {
+    const newAdminGroup = Group.create({ name: "Admin", users: [] });
+    await newAdminGroup.save();
+  }
+
+  const allGroup = await Group.findOne({ name: "All" });
+  if (!allGroup) {
+    const newAllGroup = Group.create({ name: "All", users: [] });
+    await newAllGroup.save();
+  }
 };
 
 main();

--- a/server/src/resolvers/elements.ts
+++ b/server/src/resolvers/elements.ts
@@ -146,6 +146,10 @@ export class ElementResolver {
       where: { name: "Admin" },
     });
 
+    const allGroup = await Group.findOneOrFail({
+      where: { name: "All" },
+    });
+
     if (parentId && parentId !== null) {
       element.parent = await Element.findOneOrFail(parentId, {
         relations: [
@@ -168,9 +172,12 @@ export class ElementResolver {
       ];
     } else {
       element.canModifyPermsGroups = [adminGroup];
-      element.canEditGroups = [adminGroup];
-      element.canViewGroups = [adminGroup];
-      element.canInteractGroups = [adminGroup];
+      element.canEditGroups =
+        element.type === "Database" ? [allGroup] : [adminGroup];
+      element.canViewGroups =
+        element.type === "Database" ? [allGroup] : [adminGroup];
+      element.canInteractGroups =
+        element.type === "Database" ? [allGroup] : [adminGroup];
     }
 
     // Check user has permissions to edit parent (i.e. add an element to it)


### PR DESCRIPTION
New databases with no parent will have their permissions (other than`canModifyPermissions`) set to the `All` group to temporarily fix a problem where users could not create new databases.

This does mean that all databases are fully editable and viewable by any logged-in users, and so a better solution is needed but for now, this will allow further testing.